### PR TITLE
Fixed centering on youtube card

### DIFF
--- a/public/css/jass.css
+++ b/public/css/jass.css
@@ -63,6 +63,6 @@ body{
 .youtube{
     display: flex;
     justify-content: center;
-    margin-left: 17%;
+    margin-left: 1%;
 }
 


### PR DESCRIPTION
If 17% margin left looks fine on your screen please cancel merge, could be different sizing of monitors/screens